### PR TITLE
Fix build for latest version of servant-client

### DIFF
--- a/lib/Web/OpenWeatherMap/API.hs
+++ b/lib/Web/OpenWeatherMap/API.hs
@@ -14,8 +14,7 @@ module Web.OpenWeatherMap.API (
 import Data.Proxy (Proxy(..))
 
 import Servant.API ((:>), (:<|>)(..), JSON, Get, QueryParam)
-import Servant.Client (client)
-import Servant.Common.Req (ClientM)
+import Servant.Client (ClientM, client)
 
 import Web.OpenWeatherMap.Types.CurrentWeather (CurrentWeather)
 

--- a/lib/Web/OpenWeatherMap/Client.hs
+++ b/lib/Web/OpenWeatherMap/Client.hs
@@ -7,9 +7,7 @@ module Web.OpenWeatherMap.Client (
 ) where
 
 import Network.HTTP.Client (newManager, defaultManagerSettings)
-import Servant.Client (ClientEnv(..), runClientM, ServantError)
-import Servant.Common.BaseUrl (BaseUrl(..), Scheme(..))
-import Servant.Common.Req (ClientM)
+import Servant.Client (BaseUrl(BaseUrl), ClientEnv, mkClientEnv, ClientM, Scheme(Http), ServantError, runClientM)
 
 import Web.OpenWeatherMap.Types.CurrentWeather (CurrentWeather)
 import qualified Web.OpenWeatherMap.API as API
@@ -40,7 +38,7 @@ api (Coord lat lon) = API.weatherByCoord (Just lat) (Just lon) . Just
 defaultEnv :: IO ClientEnv
 defaultEnv = do
   manager <- newManager defaultManagerSettings
-  return $ ClientEnv manager baseUrl
+  return $ mkClientEnv manager baseUrl
 
 -- XXX openweathermap.org does not support HTTPS,
 -- XXX appid is passed in clear text. Oops.

--- a/openweathermap.cabal
+++ b/openweathermap.cabal
@@ -30,7 +30,7 @@ library
     , aeson
     , http-client
     , servant
-    , servant-client >= 0.9
+    , servant-client >= 0.13
   exposed-modules:
      Web.OpenWeatherMap.API
      Web.OpenWeatherMap.Client


### PR DESCRIPTION
Various modules have been removed from servant-client, and the things previously imported from them now need to be imported from the top-level `Servant.Client` module.

The `ClientEnv` constructor now has a third parameter. Instead of using the constructor directly, now using `mkClientEnv` (which was introduced in `servant-client` 0.13, necessitating raising the minimum version on the dependency).