### PR TITLE
Fix bug where message maybe empty

### DIFF
--- a/lib/Web/OpenWeatherMap/Types/Sys.hs
+++ b/lib/Web/OpenWeatherMap/Types/Sys.hs
@@ -11,7 +11,7 @@ import Data.Aeson (FromJSON)
  
 
 data Sys = Sys
-  { message :: Double
+  { message :: Maybe Double
   , country :: Maybe String
   , sunrise :: Int
   , sunset :: Int


### PR DESCRIPTION
If the message isn't set aeson will not decode the entire message. Eg:

```
Left (DecodeFailure "Error in $.sys: key \"message\" not present" (Response {responseStatusCode = Status {statusCode = 200, statusMessage = "OK"}, responseHeaders = fromList [("Server","
```

So we have to make the field maybe.