### PR TITLE
Add forecast api endpoint

### DIFF
--- a/lib/Web/OpenWeatherMap/API.hs
+++ b/lib/Web/OpenWeatherMap/API.hs
@@ -5,10 +5,11 @@ For API key (a.k.a appid) refer to <http://openweathermap.org/appid>.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Web.OpenWeatherMap.API
-  ( weatherByName
-  , weatherByCoord
-  ) where
+module Web.OpenWeatherMap.API (
+  weatherByName,
+  weatherByCoord,
+ dailyWeatherForecast  
+) where
 
 import Data.Proxy (Proxy(..))
 
@@ -22,7 +23,10 @@ type GetCurrentWeather = AppId :> Get '[ JSON] CurrentWeather
 type AppId = QueryParam "appid" String
 
 type API
-   = "weather" :> QueryParam "q" String :> GetCurrentWeather :<|> "weather" :> QueryParam "lat" Double :> QueryParam "lon" Double :> GetCurrentWeather
+     = "weather" :> QueryParam "q" String :> GetCurrentWeather
+  :<|> "weather" :> QueryParam "lat" Double :> QueryParam "lon" Double
+                 :> GetCurrentWeather
+  :<|> "forecast" :> "daily" :> QueryParam "q" String :> GetCurrentWeather
 
 -- | Request current weather in the city.
 weatherByName ::
@@ -35,4 +39,10 @@ weatherByCoord ::
   -> Maybe Double -- ^ Longitude, e. g. 37.6155600 for Moscow.
   -> Maybe String -- ^ API key.
   -> ClientM CurrentWeather
-weatherByName :<|> weatherByCoord = client (Proxy :: Proxy API)
+  
+dailyWeatherForecast  :: Maybe String  -- ^ City name, e. g. \"Moscow\" or \"Moscow,ru\".
+  -> Maybe String  -- ^ API key.
+  -> ClientM CurrentWeather
+
+weatherByName :<|> weatherByCoord :<|> dailyWeatherForecast = client (Proxy :: Proxy API)
+

--- a/lib/Web/OpenWeatherMap/API.hs
+++ b/lib/Web/OpenWeatherMap/API.hs
@@ -4,12 +4,15 @@ For API key (a.k.a appid) refer to <http://openweathermap.org/appid>.
 -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module Web.OpenWeatherMap.API (
   weatherByName,
   weatherByCoord,
- dailyWeatherForecast  
+  dailyWeatherForecast  
 ) where
+
 
 import Data.Proxy (Proxy(..))
 
@@ -17,6 +20,7 @@ import Servant.API ((:<|>)(..), (:>), Get, JSON, QueryParam)
 import Servant.Client (ClientM, client)
 
 import Web.OpenWeatherMap.Types.CurrentWeather (CurrentWeather)
+import Web.OpenWeatherMap.Types.Forecast(Forecast)
 
 type GetCurrentWeather = AppId :> Get '[ JSON] CurrentWeather
 
@@ -26,7 +30,8 @@ type API
      = "weather" :> QueryParam "q" String :> GetCurrentWeather
   :<|> "weather" :> QueryParam "lat" Double :> QueryParam "lon" Double
                  :> GetCurrentWeather
-  :<|> "forecast" :> "daily" :> QueryParam "q" String :> GetCurrentWeather
+  :<|> "forecast" :> QueryParam "q" String :> AppId :> Get '[JSON] Forecast 
+
 
 -- | Request current weather in the city.
 weatherByName ::
@@ -42,7 +47,7 @@ weatherByCoord ::
   
 dailyWeatherForecast  :: Maybe String  -- ^ City name, e. g. \"Moscow\" or \"Moscow,ru\".
   -> Maybe String  -- ^ API key.
-  -> ClientM CurrentWeather
+  -> ClientM Forecast 
 
 weatherByName :<|> weatherByCoord :<|> dailyWeatherForecast = client (Proxy :: Proxy API)
 

--- a/lib/Web/OpenWeatherMap/Client.hs
+++ b/lib/Web/OpenWeatherMap/Client.hs
@@ -4,7 +4,8 @@ High-level client functions perfoming requests to OpenWeatherMap API.
 module Web.OpenWeatherMap.Client (
   Location(..),
   getWeather,
-  baseUrl 
+  baseUrl,
+  defaultEnv 
 ) where
 
 import Network.HTTP.Client (newManager, defaultManagerSettings)

--- a/lib/Web/OpenWeatherMap/Client.hs
+++ b/lib/Web/OpenWeatherMap/Client.hs
@@ -1,21 +1,14 @@
 {-|
 High-level client functions perfoming requests to OpenWeatherMap API.
 -}
-module Web.OpenWeatherMap.Client
-  ( Location(..)
-  , getWeather
-  ) where
+module Web.OpenWeatherMap.Client (
+  Location(..),
+  getWeather,
+  baseUrl 
+) where
 
-import Network.HTTP.Client (defaultManagerSettings, newManager)
-import Servant.Client
-  ( BaseUrl(BaseUrl)
-  , ClientEnv
-  , ClientError
-  , ClientM
-  , Scheme(Http)
-  , mkClientEnv
-  , runClientM
-  )
+import Network.HTTP.Client (newManager, defaultManagerSettings)
+import Servant.Client (BaseUrl(BaseUrl), ClientEnv, mkClientEnv, ClientM, Scheme(Http), ServantError, runClientM)
 
 import qualified Web.OpenWeatherMap.API as API
 import Web.OpenWeatherMap.Types.CurrentWeather (CurrentWeather)

--- a/lib/Web/OpenWeatherMap/Client.hs
+++ b/lib/Web/OpenWeatherMap/Client.hs
@@ -9,7 +9,15 @@ module Web.OpenWeatherMap.Client (
 ) where
 
 import Network.HTTP.Client (newManager, defaultManagerSettings)
-import Servant.Client (BaseUrl(BaseUrl), ClientEnv, mkClientEnv, ClientM, Scheme(Http), ServantError, runClientM)
+import Servant.Client
+  ( BaseUrl(BaseUrl)
+  , ClientEnv
+  , ClientError
+  , ClientM
+  , Scheme(Http)
+  , mkClientEnv
+  , runClientM
+  )
 
 import qualified Web.OpenWeatherMap.API as API
 import Web.OpenWeatherMap.Types.CurrentWeather (CurrentWeather)

--- a/lib/Web/OpenWeatherMap/Types/Forecast.hs
+++ b/lib/Web/OpenWeatherMap/Types/Forecast.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Web.OpenWeatherMap.Types.Forecast (
+  Forecast (..)
+) where
+
+import GHC.Generics (Generic)
+import Data.Aeson (FromJSON)
+import Web.OpenWeatherMap.Types.Measurement
+
+data Forecast = Forecast 
+  { cod :: String
+  , message :: Int
+  , cnt :: Int
+  , list :: [Measurement]
+  -- , city
+  } deriving (Show, Generic, FromJSON)

--- a/lib/Web/OpenWeatherMap/Types/Main.hs
+++ b/lib/Web/OpenWeatherMap/Types/Main.hs
@@ -17,6 +17,7 @@ data Main = Main
   , humidity :: Double
   , temp_min :: Double
   , temp_max :: Double
+  , feels_like :: Double
   , sea_level :: Maybe Double
   , grnd_level :: Maybe Double
   } deriving (Show, Generic, FromJSON)

--- a/lib/Web/OpenWeatherMap/Types/Measurement.hs
+++ b/lib/Web/OpenWeatherMap/Types/Measurement.hs
@@ -1,18 +1,29 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Web.OpenWeatherMap.Types.Measurement (
   Measurement (..)
 ) where
 
 import GHC.Generics (Generic)
-import Data.Aeson (FromJSON)
+import Data.Aeson 
 import Web.OpenWeatherMap.Types.Main
-import Web.OpenWeatherMap.Types.Weather 
+import Web.OpenWeatherMap.Types.Weather
+import Data.Time
+import Data.Text
 
 data Measurement = Measurement {
   main :: Main,
   weather :: [Weather],
-  dt_txt :: String
-  } deriving (Show, Generic, FromJSON)
+  dt_txt :: UTCTime
+} deriving (Show, Generic)
 
+instance FromJSON Measurement where
+  parseJSON = 
+    withObject "Measurement" $ \v -> do
+      result <- v .: "dt_txt"
+      Measurement 
+          <$> v .: "main"
+          <*> v .: "weather"
+          <*> (parseTimeM True defaultTimeLocale "%Y-%-m-%-d %H:%M:%S" result)

--- a/lib/Web/OpenWeatherMap/Types/Measurement.hs
+++ b/lib/Web/OpenWeatherMap/Types/Measurement.hs
@@ -12,6 +12,7 @@ import Web.OpenWeatherMap.Types.Weather
 
 data Measurement = Measurement {
   main :: Main,
-  weather :: [Weather]
+  weather :: [Weather],
+  dt_txt :: String
   } deriving (Show, Generic, FromJSON)
 

--- a/lib/Web/OpenWeatherMap/Types/Measurement.hs
+++ b/lib/Web/OpenWeatherMap/Types/Measurement.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Web.OpenWeatherMap.Types.Measurement (
+  Measurement (..)
+) where
+
+import GHC.Generics (Generic)
+import Data.Aeson (FromJSON)
+import Web.OpenWeatherMap.Types.Main
+import Web.OpenWeatherMap.Types.Weather 
+
+data Measurement = Measurement {
+  main :: Main,
+  weather :: [Weather]
+  } deriving (Show, Generic, FromJSON)
+

--- a/openweathermap.cabal
+++ b/openweathermap.cabal
@@ -30,7 +30,9 @@ library
     , aeson
     , http-client
     , servant
-    , servant-client >= 0.16
+    , servant-client >= 0.13
+    , time
+    , text
   exposed-modules:
      Web.OpenWeatherMap.API
      Web.OpenWeatherMap.Client

--- a/openweathermap.cabal
+++ b/openweathermap.cabal
@@ -37,6 +37,8 @@ library
      Web.OpenWeatherMap.Types.Clouds
      Web.OpenWeatherMap.Types.Coord
      Web.OpenWeatherMap.Types.CurrentWeather
+     Web.OpenWeatherMap.Types.Forecast
+     Web.OpenWeatherMap.Types.Measurement
      Web.OpenWeatherMap.Types.Main
      Web.OpenWeatherMap.Types.Sys
      Web.OpenWeatherMap.Types.Weather
@@ -54,6 +56,7 @@ executable openweathermap
       , openweathermap
       , optparse-applicative >= 0.13.0.0
       , xdg-basedir
+      , servant-client >= 0.13 && < 0.15
   else
     buildable: False
 

--- a/openweathermap.cabal
+++ b/openweathermap.cabal
@@ -58,7 +58,7 @@ executable openweathermap
       , openweathermap
       , optparse-applicative >= 0.13.0.0
       , xdg-basedir
-      , servant-client >= 0.13 && < 0.15
+      , servant-client >= 0.13
   else
     buildable: False
 

--- a/openweathermap.cabal
+++ b/openweathermap.cabal
@@ -30,7 +30,7 @@ library
     , aeson
     , http-client
     , servant
-    , servant-client >= 0.13
+    , servant-client >= 0.16
     , time
     , text
   exposed-modules:

--- a/openweathermap.cabal
+++ b/openweathermap.cabal
@@ -30,7 +30,7 @@ library
     , aeson
     , http-client
     , servant
-    , servant-client >= 0.16
+    , servant-client >= 0.13
     , time
     , text
   exposed-modules:


### PR DESCRIPTION
Hi, these changes add the forecast 5 day 3 hour api endpoint:

https://openweathermap.org/forecast5

I tried copying your style as much as I could.
But you may want to look at how I'm exporting more stuff from ` Web.OpenWeatherMap.Client` and how I implemented the testing code in `cmd/Main.hs`
I wasn't sure if my solution or simply extending the location sumtype would be preferable. Your thoughts would be appreciated.
